### PR TITLE
Fix breaking if statement

### DIFF
--- a/sat6_healthCheck.sh
+++ b/sat6_healthCheck.sh
@@ -289,7 +289,7 @@ if (( $release >= 7 ))
      else
         printError "${service} is not running"
      fi
-     if [[ chkconfig ${service} && echo "${service} enabled"]]
+     if $( chkconfig ${service} )
         then
 	  printOK "${service} is enabled"	
         else


### PR DESCRIPTION
An 'if' statement was malformed in the code, generating a syntax error. I fixed this part so now the script runs again.
