### PR TITLE
do not echo hammer admin password

### DIFF
--- a/sat6_healthCheck.sh
+++ b/sat6_healthCheck.sh
@@ -128,7 +128,7 @@ function check_hammer_config_file {
             echo -n "Please enter your admin username : "
             read username
             echo -n "Please enter your admin password : "
-            read password
+            read -s password
 
             mkdir ~/.hammer
             chmod 600 ~/.hammer


### PR DESCRIPTION
Use the `-s` option to read to prevent echoing the password to stdout.

Resolves issue #16 .
